### PR TITLE
#209 - Fix issue with ship recovery and KRASH simulation

### DIFF
--- a/Source/MASFlightComputerProxy2.cs
+++ b/Source/MASFlightComputerProxy2.cs
@@ -1548,7 +1548,8 @@ namespace AvionicsSystems
         {
             if (VesselRecoverable() > 0.0)
             {
-                GameEvents.OnVesselRecoveryRequested.Fire(vessel);
+                AltimeterSliderButtons sliderButtons = (AltimeterSliderButtons)GameObject.FindObjectOfType(typeof(AltimeterSliderButtons));
+                sliderButtons.vesselRecoveryButton.onClick.Invoke();
                 return 1.0;
             }
             else

--- a/Source/MASFlightComputerProxy2.cs
+++ b/Source/MASFlightComputerProxy2.cs
@@ -1546,7 +1546,7 @@ namespace AvionicsSystems
         /// <returns>1 if the craft can be recovered (although it is also recovered immediately), 0 otherwise.</returns>
         public double RecoverVessel()
         {
-            if (vessel.IsRecoverable)
+            if (VesselRecoverable() > 0.0)
             {
                 GameEvents.OnVesselRecoveryRequested.Fire(vessel);
                 return 1.0;
@@ -1710,7 +1710,14 @@ namespace AvionicsSystems
         /// <returns>1 if the craft can be recovered, 0 otherwise.</returns>
         public double VesselRecoverable()
         {
-            return (vessel.IsRecoverable) ? 1.0 : 0.0;
+            if (vessel.IsRecoverable)
+            {
+                // the K.R.A.S.H. mod disables the recovery button, so we shouldn't allow recovery if we are in a simulation
+                AltimeterSliderButtons sliderButtons = (AltimeterSliderButtons)GameObject.FindObjectOfType(typeof(AltimeterSliderButtons));
+                return sliderButtons.vesselRecoveryButton.enabled ? 1.0 : 0.0;
+            }
+
+            return 0.0;
         }
 
         /// <summary>


### PR DESCRIPTION
VesselRecoverable now returns 0 if the GUI recover button has been disabled (e.g. from KRASH during simulation), and RecoverVessel now checks VesselRecoverable