### PR TITLE
Redirect ASET_ClockTimer.cfg to ASET Props

### DIFF
--- a/GameData/MOARdV/MAS_ASET/ASET_ClockTimer/ASET_ClockTimer.cfg
+++ b/GameData/MOARdV/MAS_ASET/ASET_ClockTimer/ASET_ClockTimer.cfg
@@ -3,7 +3,7 @@ PROP
 	name = MAS_ASET_ClockTimer
 	MODEL
 	{
-		model = ASET/ASET_Avionics/ClassicPack/ASET_ClockTimer/ASET_ClockTimer
+		model = ASET/ASET_Props/Instruments/ASET_ClockTimer/ASET_ClockTimer
 	}
 
 	MODULE


### PR DESCRIPTION
The model for the ClockTimer appears to have been moved to ASET Props at some point.