### PR TITLE
Fixes MASFlightComputer to create GameObjects during the start function.

### DIFF
--- a/Source/MASFlightComputer.cs
+++ b/Source/MASFlightComputer.cs
@@ -1203,6 +1203,9 @@ namespace AvionicsSystems
         {
             if (HighLogic.LoadedSceneIsFlight)
             {
+                audioObject = new GameObject();
+                morseAudioObject = new GameObject();
+
                 additionalEC = 0.0f;
                 rate = Mathf.Max(0.0f, rate);
                 commandModule = part.FindModuleImplementing<ModuleCommand>();
@@ -1720,9 +1723,9 @@ namespace AvionicsSystems
         #endregion
 
         #region Audio Player
-        GameObject audioObject = new GameObject();
+        GameObject audioObject;
         AudioSource audioSource;
-        GameObject morseAudioObject = new GameObject();
+        GameObject morseAudioObject;
         AudioSource morseAudioSource;
         string morseSequence;
         float morseVolume;


### PR DESCRIPTION
This fixes the following error:
[EXC 10:00:19.247] UnityException: Internal_CreateGameObject is not allowed to be called from a MonoBehaviour constructor (or instance field initializer), call it in Awake or Start instead. Called from MonoBehaviour 'MASFlightComputer' on game object 'wbiBuffaloCommandPod'.
See "Script Serialization" page in the Unity Manual for further details.
	UnityEngine.GameObject..ctor () (at <12e76cd50cc64cf19e759e981cb725af>:0)
	AvionicsSystems.MASFlightComputer..ctor () (at <177a2c548c7640c9bc351c4169da46e0>:0)
	UnityEngine.DebugLogHandler:LogException(Exception, Object)
	ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
	UnityEngine.GameObject:AddComponent(Type)
	Part:AddModule(String, Boolean)
	Part:AddModule(ConfigNode, Boolean)
	PartLoader:ParsePart(UrlConfig, ConfigNode)
	<CompileParts>d__56:MoveNext()
	UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)