### PR TITLE
Fix #356: swap dorsal/ventral directions on MAS_RCS_Stick_ADV

### DIFF
--- a/GameData/MOARdV/MAS_ASET/RCS_Stick_ADV/RCS_Stick_ADV.cfg
+++ b/GameData/MOARdV/MAS_ASET/RCS_Stick_ADV/RCS_Stick_ADV.cfg
@@ -30,8 +30,8 @@ PROP
 			name = STICKRCSX
 			transform = Stick_TransformZ
 			variable = fc.StickTranslationY()
-			startRotation = -15,0,0
-			endRotation = 15,0,0
+			startRotation = 15,0,0
+			endRotation = -15,0,0
 			range = -1, 1
 			blend = true
 			speed = 4


### PR DESCRIPTION
this matches the RPM behavior - the translation knob is not inverted even though the keyboard buttons are