### PR TITLE
Fix MASMonitor screen camera wiping display when IVA is inactive

### DIFF
--- a/Source/MASMonitor.cs
+++ b/Source/MASMonitor.cs
@@ -345,6 +345,30 @@ namespace AvionicsSystems
         }
 
         /// <summary>
+        /// Disable the screen camera when the IVA becomes inactive (e.g. on EVA or vessel switch).
+        /// Without this, the camera renders to the main screen with its opaque-black SolidColor
+        /// clear, wiping the skybox and scaled-space bodies every frame.
+        /// </summary>
+        public override void OnBecomeInactive()
+        {
+            if (screenCamera != null)
+            {
+                screenCamera.enabled = false;
+            }
+        }
+
+        /// <summary>
+        /// Re-enable the screen camera when the IVA becomes active again.
+        /// </summary>
+        public override void OnBecomeActive()
+        {
+            if (screenCamera != null)
+            {
+                screenCamera.enabled = true;
+            }
+        }
+
+        /// <summary>
         /// Just in case we lose context.
         /// </summary>
         public override void OnUpdate()


### PR DESCRIPTION
## Problem

When the active vessel switches (e.g. a crew member goes on EVA, or you switch to another vessel), KSP calls `OnBecomeInactive()` on all `InternalModule` instances. `MASMonitor` does not override this method.

The monitor's `screenCamera` is left **enabled** with `ClearFlags.SolidColor` and an opaque-black `backgroundColor`. With `targetTexture` no longer pointing to a live render texture, Unity falls back to rendering the camera to the main display. This wipes the skybox and scaled-space bodies (Mun, Kerbin, stars, etc.) every frame until the vessel is reactivated.

## Fix

Override `OnBecomeInactive()` to disable `screenCamera`, and `OnBecomeActive()` to re-enable it. The monitor has nothing to render when the IVA is inactive, so disabling the camera is correct behaviour.

```csharp
public override void OnBecomeInactive()
{
    if (screenCamera != null)
    {
        screenCamera.enabled = false;
    }
}

public override void OnBecomeActive()
{
    if (screenCamera != null)
    {
        screenCamera.enabled = true;
    }
}
```

## Reproduction

1. Board a vessel that has a JSI BasicMFD prop using `MASMonitor`
2. Have a crew member go on EVA, or switch to another vessel
3. Observe: background goes black; skybox, Mun, Kerbin all invisible
4. Switch back to the vessel: display returns to normal