### PR TITLE
Fix VesselDistanceComparer throwing ArgumentException when vessel position is NaN

### DIFF
--- a/Source/MASFlightComputerProxy.cs
+++ b/Source/MASFlightComputerProxy.cs
@@ -259,7 +259,7 @@ namespace AvionicsSystems
             {
                 float distA = Vector3.SqrMagnitude(a.GetTransform().position - vesselPosition);
                 float distB = Vector3.SqrMagnitude(b.GetTransform().position - vesselPosition);
-                return (int)(distA - distB);
+                return distA.CompareTo(distB);
             }
         }
 


### PR DESCRIPTION
## Problem

`MASFlightComputerProxy.VesselDistanceComparer.Compare()` uses:

```csharp
return (int)(distA - distB);
```

`Array.Sort()` requires a consistent `IComparer`. If any vessel's `GetTransform().position` contains `NaN` (which can occur with certain save states), then `distA` or `distB` is `NaN`, and `(int)(NaN - NaN)` evaluates to `0` regardless of operand order. This violates the sort contract (transitivity) and causes `Array.Sort()` to throw:

```
ArgumentException: Unable to sort because the IComparer.Compare() method
returns inconsistent results. IComparer:
'AvionicsSystems.MASFlightComputerProxy+VesselDistanceComparer'
```

This fires on every `FixedUpdate` (50×/sec) while in IVA with nearby vessels, generating thousands of log entries and breaking any MFD page that displays neighbouring vessel information.

The same `(int)` cast also overflows silently for very large squared distances (> `int.MaxValue` ≈ 46,340 km), producing incorrect sort order at interplanetary distances.

## Fix

Replace the cast with `float.CompareTo()`, which handles `NaN` and large values correctly:

```csharp
return distA.CompareTo(distB);
```

One character change; no behaviour change for normal finite distances.